### PR TITLE
feat: push 알림 클릭 시, 채팅방으로 이동

### DIFF
--- a/app/src/main/java/com/example/bookwhale/screen/main/MainActivity.kt
+++ b/app/src/main/java/com/example/bookwhale/screen/main/MainActivity.kt
@@ -37,8 +37,8 @@ class MainActivity : BaseActivity<MainViewModel, ActivityMainBinding>() {
 
     override fun getViewBinding(): ActivityMainBinding = ActivityMainBinding.inflate(layoutInflater)
 
+    private val roomId by lazy { intent.getStringExtra(ROOM_ID) }
     private var searchStatus = SearchStatus.SEARCH_NOT
-    private val eventBus by inject<EventBus>()
     private val messageChannel by inject<MessageChannel>()
     private val disposable = CompositeDisposable() // Disposable 관리
     private val backBtnSubject = PublishSubject.create<Boolean>() // backBtn 이벤트를 발생시킬 수 있는 Subject
@@ -49,6 +49,8 @@ class MainActivity : BaseActivity<MainViewModel, ActivityMainBinding>() {
         initButton()
         subscribeMessageChannel()
         viewModel.getMyInfo()
+
+        roomId?.let { passToChatRoom() }
     }
 
     private fun initButton() = with(binding) {
@@ -205,6 +207,11 @@ class MainActivity : BaseActivity<MainViewModel, ActivityMainBinding>() {
         backBtnSubject.onNext(true)
     }
 
+    private fun passToChatRoom() {
+        val intent = ChatRoomActivity.newIntent(this@MainActivity, roomId as String)
+        startActivity(intent)
+    }
+
     override fun onPause() {
         super.onPause()
 
@@ -219,10 +226,12 @@ class MainActivity : BaseActivity<MainViewModel, ActivityMainBinding>() {
     }
 
     companion object {
-        fun newIntent(context: Context) = Intent(context, MainActivity::class.java)
+        fun newIntent(context: Context, roomId: String? = null) = Intent(context, MainActivity::class.java).apply {
+            putExtra(ROOM_ID, roomId)
+        }
 
+        const val ROOM_ID = "roomId"
         const val BACK_BTN_EXIT_TIMEOUT = 2000 // 연속된 Back 버튼의 시간 간격 (2초안에 백버튼 2번 클릭시 앱 종료)
-
         const val TAG = "MainActivity"
 
         enum class SearchStatus {

--- a/app/src/main/java/com/example/bookwhale/screen/splash/SplashActivity.kt
+++ b/app/src/main/java/com/example/bookwhale/screen/splash/SplashActivity.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.lifecycleScope
 import com.example.bookwhale.R
 import com.example.bookwhale.databinding.ActivitySplashBinding
 import com.example.bookwhale.screen.base.BaseActivity
+import com.example.bookwhale.screen.chatroom.ChatRoomActivity
 import com.example.bookwhale.screen.login.LoginActivity
 import com.example.bookwhale.screen.main.MainActivity
 import com.google.android.gms.tasks.OnCompleteListener
@@ -23,6 +24,8 @@ class SplashActivity : BaseActivity<SplashViewModel, ActivitySplashBinding>() {
     override val viewModel by viewModel<SplashViewModel>()
 
     override fun getViewBinding(): ActivitySplashBinding = ActivitySplashBinding.inflate(layoutInflater)
+
+    private val roomId by lazy { intent.extras?.get(FCM_DATA_ROOM_ID) }
 
     override fun initViews(): Unit = with(binding) {
         getCurrentDeviceToken()
@@ -61,9 +64,7 @@ class SplashActivity : BaseActivity<SplashViewModel, ActivitySplashBinding>() {
             delay(1500L) // 추후 특정 시간 걸리는 작업을 염두하고 임의로 딜레이를 주었다.
             binding.progressBar.isGone = true
 
-            val intent = MainActivity.newIntent(this@SplashActivity)
-            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
-            startActivity(intent)
+            passToMain()
         }
     }
 
@@ -88,10 +89,20 @@ class SplashActivity : BaseActivity<SplashViewModel, ActivitySplashBinding>() {
             delay(1500L) // 추후 특정 시간 걸리는 작업을 염두하고 임의로 딜레이를 주었다.
             binding.progressBar.isGone = true
 
-            val intent = LoginActivity.newIntent(this@SplashActivity)
-            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
-            startActivity(intent)
+            passToLogin()
         }
+    }
+
+    private fun passToMain() {
+        val intent = MainActivity.newIntent(this@SplashActivity, roomId as String?)
+        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        startActivity(intent)
+    }
+
+    private fun passToLogin() {
+        val intent = LoginActivity.newIntent(this@SplashActivity)
+        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        startActivity(intent)
     }
 
     private fun handleUnExcepted(code: String) {
@@ -101,6 +112,8 @@ class SplashActivity : BaseActivity<SplashViewModel, ActivitySplashBinding>() {
 
     companion object {
         fun newIntent(context: Context) = Intent(context, SplashActivity::class.java)
+
+        const val FCM_DATA_ROOM_ID = "roomId"
     }
 
 }

--- a/app/src/main/java/com/example/bookwhale/util/FirebaseInstanceIDService.kt
+++ b/app/src/main/java/com/example/bookwhale/util/FirebaseInstanceIDService.kt
@@ -64,10 +64,10 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
             Log.i(TAG,"Room Connected: RoomId = $roomId")
         } else {
             Log.i(TAG,"Room Unconnected")
-            //sendNotification(title, description)
-            //roomId?.let { myPreferenceManager.putRoomId(it) }
             messageToChannel(title, description, roomId)
         }
+
+        //sendNotification(title, description)
         // Also if you intend on generating your own notifications as a result of a received FCM
         // message, here is where that should be initiated. See sendNotification method below.
     }
@@ -83,13 +83,6 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
         Log.d(TAG, "Refreshed token: $token")
     }
     // [END on_new_token]
-
-    private fun provideEvent() {
-        Log.i(TAG,"PROVIDEVENT")
-        GlobalScope.launch {
-            eventBus.produceEvent(Events.ChatNoti)
-        }
-    }
 
     private fun messageToChannel(title: String?, message: String?, roomId: String?) {
         GlobalScope.launch {


### PR DESCRIPTION
앱이 background / killed 상태일 때 푸쉬 알림을 누르면
Splash -> Main -> ChatRoom의 순서로 채팅방에 입장한다. (로그인 정보 및 액티비티 스택 쌓기 위해 순서대로 연결)